### PR TITLE
Optional date filter for merged prs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The `github-pr-comments` CLI command fetches merged pull request comments from a
 
 ### Key Features
 - Fetches only **merged PRs** for a specific repository, base branch, and milestone.
+- Optional **date filter** (`--merged-since`): include only PRs merged on or after a given `YYYY-MM-DD` date.
 - Supports **keyword filtering**, requiring one or more phrases to appear in each comment.  
 - Collects and groups comments by **author**, ensuring each PR is listed once per tester.  
 - Outputs results to the console and writes a **`collaborator-tester.md`** markdown file.  
@@ -50,9 +51,13 @@ The `github-pr-comments` CLI command fetches merged pull request comments from a
      --repo=your_repo \
      --base=main \
      --milestone=v1.0.0 \
+     --merged-since=2023-01-01 \
      --keyword="I have tested this item" \
      --keyword="OK to merge"
    ```
+
+  > [!TIP]
+  > The `merged-since` date filter is optional and especially useful if you have a milestone with multiple releases (alpha, beta, etc.) and want to reflect the tests accurately.
 
 ## How it works
 
@@ -66,7 +71,7 @@ The `github-pr-comments` CLI command fetches merged pull request comments from a
 ## Example
 
 ```bash
-php cli/github-pr-comments.php --milestone=v1.0.0 --keyword="tested" --keyword="LGTM"
+php cli/github-pr-comments.php --merged-since=2023-01-01 --milestone=v1.0.0 --keyword="tested" --keyword="LGTM"
 ```
 
 Get a list of all possible options:

--- a/cli/github-pr-comments.php
+++ b/cli/github-pr-comments.php
@@ -32,15 +32,25 @@ class GithubCommentsCli extends AbstractCommand
         $this->getDefinition()->addOption(
             new InputOption('keyword', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter keyword(s)')
         );
+        // Date filter for merged PRs (optional)
+        $this->getDefinition()->addOption(new InputOption('merged-since', null, InputOption::VALUE_OPTIONAL, 'Date filter for merged PRs (YYYY-MM-DD)'));
     }
 
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
-        $token     = null !== $input->getOption('token') ? $input->getOption('token') : $_ENV['GITHUB_TOKEN'] ?? null;
-        $owner     = null !== $input->getOption('owner') ? $input->getOption('owner') : $_ENV['GITHUB_OWNER'] ?? null;
-        $repo      = null !== $input->getOption('repo') ? $input->getOption('repo') : $_ENV['GITHUB_REPO'] ?? null;
-        $base      = null !== $input->getOption('base') ? $input->getOption('base') : $_ENV['GITHUB_BASE'] ?? '6.0-dev';
-        $milestone = null !== $input->getOption('milestone') ? $input->getOption('milestone') : $_ENV['GITHUB_MILESTONE'] ?? 'Joomla! 6.0.0';
+        $token       = null !== $input->getOption('token') ? $input->getOption('token') : $_ENV['GITHUB_TOKEN'] ?? null;
+        $owner       = null !== $input->getOption('owner') ? $input->getOption('owner') : $_ENV['GITHUB_OWNER'] ?? null;
+        $repo        = null !== $input->getOption('repo') ? $input->getOption('repo') : $_ENV['GITHUB_REPO'] ?? null;
+        $base        = null !== $input->getOption('base') ? $input->getOption('base') : $_ENV['GITHUB_BASE'] ?? '6.0-dev';
+        $milestone   = null !== $input->getOption('milestone') ? $input->getOption('milestone') : $_ENV['GITHUB_MILESTONE'] ?? 'Joomla! 6.0.0';
+        $mergedSince = null !== $input->getOption('merged-since') ? $input->getOption('merged-since') : null;
+
+        // Validate date filter if present
+        if ($mergedSince && !\DateTime::createFromFormat('Y-m-d', $mergedSince)) {
+            $output->writeln('<error>Invalid date format for --merged-since. Please use YYYY-MM-DD.</error>');
+            return 1;
+        }
+
         // Build keywords list: use CLI options if provided, otherwise env
         $cliKeywords = $input->getOption('keyword');
         if (\is_array($cliKeywords) && \count($cliKeywords) > 0) {
@@ -83,6 +93,10 @@ GQL;
         do {
             // Build search string including milestone
             $queryString = \sprintf('repo:%s/%s is:pr is:merged base:%s milestone:"%s"', $owner, $repo, $base, $milestone);
+            // Add date filter if provided
+            if ($mergedSince) {
+                $queryString .= ' merged:>=' . $mergedSince;
+            }
             $payload     = ['query' => $query, 'variables' => ['queryString' => $queryString, 'after' => $after]];
             $response    = $client->post('https://api.github.com/graphql', json_encode($payload));
             $data        = json_decode($response->getBody());
@@ -97,15 +111,23 @@ GQL;
                 return 1;
             }
 
-            $output->writeln(\sprintf(
-                "Found %d PRs in %s/%s with milestone '%s':",
-                \count($data->data->search->nodes),
-                $owner,
-                $repo,
-                $milestone
-            ));
+            $outputResults = ($mergedSince) ? 
+                \sprintf("Found %d PRs merged since %s in %s/%s with milestone '%s':",
+                    \count($data->data->search->nodes),
+                    $mergedSince,
+                    $owner,
+                    $repo,
+                    $milestone
+                ) : \sprintf(
+                    "Found %d PRs in %s/%s with milestone '%s':",
+                    \count($data->data->search->nodes),
+                    $owner,
+                    $repo,
+                    $milestone
+                );
 
-            $count = 0;
+            $output->writeln($outputResults);
+
             foreach ($data->data->search->nodes as $pr) {
 
                 foreach ($pr->comments->nodes as $comment) {
@@ -160,7 +182,6 @@ GQL;
             foreach ($comments as $comment) {
                 $mdFull .= "    - PR #{$comment['pr']}: {$comment['title']}\n";
                 $output->writeln(\sprintf(" - PR #%d: %s", $comment['pr'], $comment['title']));
-                // $output->writeln(sprintf("   Comment: %s", $comment['comment']));
             }
         }
 

--- a/cli/github-pr-comments.php
+++ b/cli/github-pr-comments.php
@@ -46,7 +46,7 @@ class GithubCommentsCli extends AbstractCommand
         $mergedSince = null !== $input->getOption('merged-since') ? $input->getOption('merged-since') : null;
 
         // Validate date filter if present
-        if ($mergedSince && !\DateTime::createFromFormat('Y-m-d', $mergedSince)) {
+        if ($mergedSince && (!($date = \DateTime::createFromFormat('Y-m-d', $mergedSince)) || $date->format('Y-m-d') !== $mergedSince)) {
             $output->writeln('<error>Invalid date format for --merged-since. Please use YYYY-MM-DD.</error>');
             return 1;
         }

--- a/cli/github-pr-comments.php
+++ b/cli/github-pr-comments.php
@@ -111,8 +111,9 @@ GQL;
                 return 1;
             }
 
-            $outputResults = ($mergedSince) ? 
-                \sprintf("Found %d PRs merged since %s in %s/%s with milestone '%s':",
+            $outputResults = ($mergedSince) ?
+                \sprintf(
+                    "Found %d PRs merged since %s in %s/%s with milestone '%s':",
                     \count($data->data->search->nodes),
                     $mergedSince,
                     $owner,


### PR DESCRIPTION
### Summary of Changes

This pull request adds an optional date filter, allowing users to include only pull requests merged on or after a specified date. Documentation and output messaging are updated to reflect this new feature, and input validation is added for the date format.

This filter is especially useful if you have a milestone with multiple releases (alpha, beta, etc.) and want to reflect the tests accurately.

**New Feature: Date Filter for Merged PRs**
* Added support for a `--merged-since` option in `cli/github-pr-comments.php` to filter PRs by merge date (`YYYY-MM-DD`).
* Validates the date format for the `--merged-since` option and provides an error message if the format is incorrect.
* Updates the GitHub search query to include the merge date filter when specified.
* Modifies CLI output to indicate when results are filtered by merge date.